### PR TITLE
[SYAL-2487] The historical properties of the Settings are N/A

### DIFF
--- a/.github/workflows/dev.workflow.yml
+++ b/.github/workflows/dev.workflow.yml
@@ -15,11 +15,11 @@ jobs:
       date: ${{ steps.date.outputs.date }}
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 1.8 & run tests & generate artifacts
+      - name: Set up JDK 17 & run tests & generate artifacts
         uses: actions/setup-java@v4
         with:
           distribution: adopt
-          java-version: 8
+          java-version: 17
           overwrite-settings: false
       - id: date
         run: echo "date=$(date +'%y%m%d' | cut -c 2-)" >> $GITHUB_OUTPUT
@@ -34,22 +34,22 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - id: version
-        run: echo "version=${{ needs.prep.outputs.ver }}-SNAPSHOT-${{ needs.prep.outputs.date }}-${{ needs.prep.outputs.rev }}" >> $GITHUB_OUTPUT
+        run: echo "version=${{ needs.prep.outputs.ver }}-${{ needs.prep.outputs.date }}-${{ needs.prep.outputs.rev }}" >> $GITHUB_OUTPUT
   build:
     runs-on: ubuntu-latest
     needs: versiongenerate
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 1.8 & run tests & generate artifacts
+      - name: Set up JDK 17 & run tests & generate artifacts
         uses: actions/setup-java@v4
         with:
           distribution: adopt
-          java-version: 8
+          java-version: 17
           overwrite-settings: false
       - name: Version set
         run: mvn versions:set versions:commit -DnewVersion=${{ needs.versiongenerate.outputs.version }}
       - name: Build and test with Maven
-        run: mvn clean install -DskipTests
+        run: mvn -B clean install -DskipTests
       - name: PMD check
         run: mvn pmd:check
       - id: getfilename

--- a/src/main/java/com/avispl/symphony/dal/infrastructure/management/jabra/cloudplatform/common/constants/Constant.java
+++ b/src/main/java/com/avispl/symphony/dal/infrastructure/management/jabra/cloudplatform/common/constants/Constant.java
@@ -50,6 +50,7 @@ public class Constant {
 	public static final String LIST_EMPTY_WARNING = "The list of %s is empty, returning empty collection";
 	public static final String OBJECT_EMPTY_WARNING = "The %s is null, returning empty collection";
 	public static final String UNSUPPORTED_MAP_PROPERTY_WARNING = "Unsupported %s with property %s";
+	public static final String STATISTICS_EMPTY_WARNING = "The statistics are empty, returning empty map.";
 
 	//	Fail messages
 	public static final String READ_PROPERTIES_FILE_FAILED = "Failed to load properties file: ";


### PR DESCRIPTION
1. Update the `dev.workflow.yml` file to create the build version using GitHub CI/CD.
  - The adapter build
     <img width="523" height="46" alt="image" src="https://github.com/user-attachments/assets/8093e5bc-9ae0-4026-91ae-f7aa8a5a5eeb" />
  - The adapter property
    <img width="592" height="319" alt="image" src="https://github.com/user-attachments/assets/2575b6f0-a573-491c-8a6b-48b85a7c3ea9" />
2. Fix the historical properties of the Settings is not N/A.
   <img width="591" height="379" alt="image" src="https://github.com/user-attachments/assets/a4a1e70f-e9f1-492e-8ac7-c2af550ae7be" />
3. Add the dynamic statistics for `LastMonitoringCycleDuration(s)` and `MonitoredDevicesTotal` from __AdapterMetadata__.
   <img width="324" height="68" alt="image" src="https://github.com/user-attachments/assets/c6d1dce6-72c5-4ebd-b966-5e4e40eece3b" />